### PR TITLE
Improve error message on non Win

### DIFF
--- a/WConio2.py
+++ b/WConio2.py
@@ -135,7 +135,7 @@ except ImportError as e:
         "https://learn.microsoft.com/en-us/cpp/c-runtime-library/console-and-port-i-o"))
     print(msg)
     raise e
-    #raise ImportError(msg) from e  # @TODO: frop Py2 and use this line
+    #raise ImportError(msg) from e  # @TODO: drop Py2 and use this line
 # missing from 2.7 wintypes
 CHAR = ctypes.c_char
 LPDWORD = ctypes.POINTER(DWORD)

--- a/WConio2.py
+++ b/WConio2.py
@@ -121,14 +121,24 @@ __keydict = {
 
 # connect to kernel32.dll, which actually does all the business.
 
+import sys
 import ctypes
-from ctypes import windll
-from ctypes.wintypes import *
+try:
+    from ctypes import windll
+    from ctypes.wintypes import *
+    import msvcrt
+except ImportError as e:
+    msg = "\n".join((
+        "Some items not available (maybe it's the wrong platform).",
+        "Note that conio.h is only supported on Windows.",
+        "For more details, please check: "
+        "https://learn.microsoft.com/en-us/cpp/c-runtime-library/console-and-port-i-o"))
+    print(msg)
+    raise e
+    #raise ImportError(msg) from e  # @TODO: frop Py2 and use this line
 # missing from 2.7 wintypes
 CHAR = ctypes.c_char
 LPDWORD = ctypes.POINTER(DWORD)
-import msvcrt
-import sys
 
 # Python 2 and 3 handle wchar type initializers differently
 # this is meant to deal with that

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Build Tools',
     'License :: OSI Approved :: MIT License',
+    'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3',
   ],


### PR DESCRIPTION
This is only supposed to be run on *Win*, but it can end up on other platforms. Also the error message can be confusing for some users, as shown in [\[SO\]: I can't use WConio2 on python](https://stackoverflow.com/q/74814064/4788546).

There was another package with the same problem, I submitted [\[GitHub\]: Prevent .whl installation (OOTB) on non Win](https://github.com/enthought/comtypes/pull/394), but it wasn't *OK*. I then submitted another *PR* where I inspired this one from.

Note: I also mentioned *WConio2* in [\[SO\]: Install win32com on MacOs and Linux (@CristiFati's answer)](https://stackoverflow.com/a/65030870/4788546).


On another (completely unrelated) topic, this module is full of ***U**ndefined **B**ehavior*s, and I wonder how come there aren't lots of bug reports. Check [\[SO\]: C function called from Python via ctypes returns incorrect value (@CristiFati's answer)](https://stackoverflow.com/a/58611011/4788546) for more details.