### PR TITLE
Fix: AttributeError: Function 'SetConsoleTitle' not found

### DIFF
--- a/WConio2.py
+++ b/WConio2.py
@@ -449,7 +449,7 @@ def puttext(left, top, right, bottom, source):
     _releaseconout(hConOut)
 
 def settitle(title):
-    if kernel32.SetConsoleTitle(title) == 0:
+    if kernel32.SetConsoleTitleW(title) == 0:
         raise error("settitle failed")
 
 def kbhit():


### PR DESCRIPTION
Fix for #1.

***Python 2* specific**: the argument will have to be *unicode* (`settitle(u"some title")`), otherwise it will generate ***UB*** (most likely, only 1<sup>st</sup> letter will be considered).
